### PR TITLE
Fix invalid new password validation error

### DIFF
--- a/ckanext/security/validators.py
+++ b/ckanext/security/validators.py
@@ -3,6 +3,7 @@ import string
 from ckan import authz
 from ckan.common import _
 from ckan.lib.navl.dictization_functions import Missing
+from ckan.logic import ValidationError
 
 
 MIN_PASSWORD_LENGTH = 10
@@ -14,12 +15,17 @@ MIN_LEN_ERROR = (
 
 
 def user_password_validator(key, data, errors, context):
+    # joeg: somehow key is a tuple: ('password1', ), but value is a string
+    field = key[0]
     value = data[key]
 
     if isinstance(value, Missing):
         pass  # Already handeled in core
     elif not isinstance(value, basestring):
-        raise ValueError(_('Passwords must be strings.'))
+        raise ValidationError(
+            {field: [_('Passwords must be strings.')]},
+            error_summary={_('Password'): _('invalid new password')}
+        )
     elif value == '':
         pass  # Already handeled in core
     else:
@@ -31,7 +37,10 @@ def user_password_validator(key, data, errors, context):
             any(x in string.punctuation for x in value)
         ]
         if len(value) < MIN_PASSWORD_LENGTH or sum(rules) < 3:
-            raise ValueError(_(MIN_LEN_ERROR.format(MIN_PASSWORD_LENGTH)))
+            raise ValidationError(
+                {field: [_(MIN_LEN_ERROR.format(MIN_PASSWORD_LENGTH))]},
+                error_summary={_('Password'): _('invalid new password')}
+            )
 
 
 def old_username_validator(key, data, errors, context):


### PR DESCRIPTION
Root reason:

`ckanext.security.validators.user_password_validator` raise a `ValueError`
instead of a `ckan.logic.ValidationError`, ckan can not handle it in
`core.ckan.controllers.user._save_edit`

Solution:
Raise `ValidationError` with correct args then it can be handled.

External: WR277492