### PR TITLE
Raise Invalid exception in user_password_validator

### DIFF
--- a/ckanext/security/validators.py
+++ b/ckanext/security/validators.py
@@ -2,8 +2,7 @@ import string
 
 from ckan import authz
 from ckan.common import _
-from ckan.lib.navl.dictization_functions import Missing
-from ckan.logic import ValidationError
+from ckan.lib.navl.dictization_functions import Missing, Invalid
 
 
 MIN_PASSWORD_LENGTH = 10
@@ -15,17 +14,12 @@ MIN_LEN_ERROR = (
 
 
 def user_password_validator(key, data, errors, context):
-    # joeg: somehow key is a tuple: ('password1', ), but value is a string
-    field = key[0]
     value = data[key]
 
     if isinstance(value, Missing):
         pass  # Already handeled in core
     elif not isinstance(value, basestring):
-        raise ValidationError(
-            {field: [_('Passwords must be strings.')]},
-            error_summary={_('Password'): _('invalid new password')}
-        )
+        raise Invalid(_('Passwords must be strings.'))
     elif value == '':
         pass  # Already handeled in core
     else:
@@ -37,10 +31,7 @@ def user_password_validator(key, data, errors, context):
             any(x in string.punctuation for x in value)
         ]
         if len(value) < MIN_PASSWORD_LENGTH or sum(rules) < 3:
-            raise ValidationError(
-                {field: [_(MIN_LEN_ERROR.format(MIN_PASSWORD_LENGTH))]},
-                error_summary={_('Password'): _('invalid new password')}
-            )
+            raise Invalid(_(MIN_LEN_ERROR.format(MIN_PASSWORD_LENGTH)))
 
 
 def old_username_validator(key, data, errors, context):


### PR DESCRIPTION
Raise Invalid instead of ValidationError is a better way for form,
according to other validators.

External: WR277308