### PR TITLE
Make plugin name not vendor specific

### DIFF
--- a/ckanext/security/plugin.py
+++ b/ckanext/security/plugin.py
@@ -5,7 +5,7 @@ import ckan.logic.schema
 from ckanext.security import schema
 
 
-class CatalystSecurityPlugin(plugins.SingletonPlugin):
+class CkanSecurityPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IConfigurer)
     plugins.implements(plugins.IRoutes)
 

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,6 @@ setup(
     entry_points=\
     """
     [ckan.plugins]
-    security=ckanext.security.plugin:CatalystSecurityPlugin
+    security=ckanext.security.plugin:CkanSecurityPlugin
     """,
 )


### PR DESCRIPTION
Remove "catalyst" from this plugin, as the intention is to merge all of
the changes from this plugin in to ckan itself.

This PR fixes issue #1 .