### PR TITLE
fix static file requests regenerating CSRF token

### DIFF
--- a/ckanext/security/middleware.py
+++ b/ckanext/security/middleware.py
@@ -41,7 +41,10 @@ class CSRFMiddleware(object):
         self.session.save()
 
         resp = request.get_response(self.app) if self.is_valid(request) else HTTPForbidden(CSRF_ERR)
-        return self.add_new_token(resp)(environ, start_response)
+        # Avoid updating the CSRF token with every static file served
+        if 'text/html' in resp.headers['Content-type']:
+            resp = self.add_new_token(resp)
+        return resp(environ, start_response)
 
     def is_valid(self, request):
         return request.is_safe() or self.unsafe_request_is_valid(request)


### PR DESCRIPTION
Previously every static file request, for example js,css,woff files
would regenerate and update the CSRF token set in the cookie. This meant
that if a user submitted a form before the page was finished loading, their
CSRF token would be older than the one on the server and so the request
would fail.