### PR TITLE
support ckan 2.7 and redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,11 @@ beaker.session.cookie_domain = 192.168.232.65
 ### ckanext-security configuration options
 ```ini
 ## Security
-ckanext.security.memcached = 127.0.0.1:11211  # Memcached URL
 ckanext.security.domain = 192.168.232.65      # Cookie domain
+
+ckanext.security.redis.host = 127.0.0.1
+ckanext.security.redis.port = 6379
+ckanext.security.redis.db = 1                 # ckan uses db 0
 
 # 15 minute timeout with 10 attempts
 ckanext.security.lock_timeout = 900           # Login throttling lock period

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ A notification email will be sent to locked out users.
 stack. This requires to patch `ckan.config.middleware.pylons_app`. The patch is
 currently available in the data.govt.nz [CKAN repository](https://github.com/data-govt-nz/ckan/) on the `dia` branch,
 or [commit `74f78865`](https://github.com/data-govt-nz/ckan/commit/74f78865b8825c91d1dfe6b189228f4b975610a3) for cherry-pick.
-* A running memcached instance and `libmemcached-dev`.
 
 ### Changes to `who.ini`
 You will need at least the following setting ins your `who.ini`
@@ -57,7 +56,7 @@ plugins =
 [authenticators]
 plugins =
     ckanext.security.authenticator:CKANLoginThrottle
-    ckanext.security.authenticator:BeakerMemcachedAuth
+    ckanext.security.authenticator:BeakerRedisAuth
 ```
 
 ### Changes to CKAN config
@@ -75,9 +74,8 @@ beaker.session.httponly = true
 beaker.session.secure = true
 beaker.session.timeout = 3600
 beaker.session.save_accessed_time = true
-beaker.session.type = ext:memcached
-beaker.session.url = 127.0.0.1:11211
-beaker.session.memcache_module = pylibmc
+beaker.session.type = redis
+beaker.session.url = 127.0.0.1:6739
 beaker.session.cookie_expires = true
 # Your domain should show here.
 beaker.session.cookie_domain = 192.168.232.65
@@ -106,11 +104,6 @@ pip install --process-dependency-links -e 'https://github.com/data-govt-nz/ckane
 *NOTE: The ``--process-dependency-links` flag has officially been deprecated, but
 has not been removed from pip, because it is the currently the only
 setuptools-supported way for specifying private repo dependencies*
-
-Then modify your CKAN config to point the extension at your memcached instance:
-```ini
-ckanext.security.memcached = 127.0.0.1:11211
-```
 
 Finally, add `security` to `ckan.plugins` in your config file.
 

--- a/ckanext/security/authenticator.py
+++ b/ckanext/security/authenticator.py
@@ -62,12 +62,12 @@ class CKANLoginThrottle(UsernamePasswordAuthenticator):
         throttle.increment()
 
 
-class BeakerMemcachedAuth(object):
+class BeakerRedisAuth(object):
     implements(IAuthenticator)
 
     def authenticate(self, environ, identity):
         # At this stage, the identity has already been validated from the cookie
-        # and memcache (use_beaker middleware). We simply return the user id
+        # and redis (use_beaker middleware). We simply return the user id
         # from the identity object if it's there, or None if the user's
         # identity is not verified.
         return identity.get('repoze.who.userid', None)

--- a/ckanext/security/cache/clients.py
+++ b/ckanext/security/cache/clients.py
@@ -1,29 +1,26 @@
+import redis
 from ckan.common import config
 
-import pylibmc
-
-
-class MemcachedClient(object):
+class RedisClient(object):
     prefix = ''
 
     def __init__(self):
-        url = config['ckanext.security.memcached']
-        conf = {"binary": True, "behaviors": {"tcp_nodelay": True, "ketama": True}}
-        self.cli = pylibmc.Client([url], **conf)
+        host = config['ckanext.security.redis.host']
+        port = config['ckanext.security.redis.port']
+        db = config['ckanext.security.redis.db']
+        self.client = redis.StrictRedis(host=host, port=port, db=db)
 
     def get(self, key):
-        return self.cli.get(self.prefix + key)
+        return self.client.get(self.prefix + key)
 
     def set(self, key, value):
-        return self.cli.set(self.prefix + key, value)
+        return self.client.set(self.prefix + key, value)
 
     def delete(self, key):
-        return self.cli.delete(self.prefix + key)
+        return self.client.delete(self.prefix + key)
 
+class CSRFClient(RedisClient):
+    prefix = 'security_csrf_'
 
-class MemcachedCSRFClient(MemcachedClient):
-    prefix = 'sec_csrf_'
-
-
-class MemcachedThrottleClient(MemcachedClient):
-    pefix = 'sec_throttle_'
+class ThrottleClient(RedisClient):
+    prefix = 'security_throttle_'

--- a/ckanext/security/cache/login.py
+++ b/ckanext/security/cache/login.py
@@ -5,7 +5,7 @@ import time
 from ckan.common import config
 
 from ckanext.security.mailer import notify_lockout
-from ckanext.security.cache.clients import MemcachedThrottleClient
+from ckanext.security.cache.clients import ThrottleClient
 
 
 log = logging.getLogger(__name__)
@@ -19,7 +19,7 @@ class LoginThrottle(object):
     def __init__(self, user, remote_addr):
         self.request_time = time.time()
         self.user = user
-        self.cli = MemcachedThrottleClient()
+        self.cli = ThrottleClient()
         self.remote_addr = remote_addr
 
         # Separately caching user name, because str(user) yields an unwieldy

--- a/ckanext/security/middleware.py
+++ b/ckanext/security/middleware.py
@@ -6,6 +6,9 @@ from webob.exc import HTTPForbidden
 
 from ckanext.security.cache.clients import CSRFClient
 
+import logging
+log = logging.getLogger(__name__)
+
 try:
     from hmac import compare_digest
 except ImportError:
@@ -18,6 +21,9 @@ CSRF_ERR = 'CSRF authentication failed. Token missing or invalid.'
 
 class Request(webob.Request):
     def is_secure(self):
+        # allow requests which have the x-forwarded-proto of https (inserted by nginx)
+        if self.headers.get('X-Forwarded-Proto') == 'https':
+            return True 
         return self.scheme == 'https'
 
     def is_safe(self):
@@ -34,7 +40,8 @@ class Request(webob.Request):
         if not self.referer:
             return False 
         else:
-            return self.referer.startswith("https://{}/".format(self.host))
+            match = "https://{}/".format(self.host)
+            return self.referer.startswith(match)
 
 
 class CSRFMiddleware(object):
@@ -50,10 +57,12 @@ class CSRFMiddleware(object):
         self.session = environ['beaker.session']
         self.session.save()
 
-        resp = request.get_response(self.app) if self.is_valid(request) else HTTPForbidden(CSRF_ERR)
-        # Avoid updating the CSRF token with every static file served
-        if 'text/html' in resp.headers['Content-type']:
-            resp = self.add_new_token(resp)
+        if self.is_valid(request):
+            resp = request.get_response(self.app)
+        else:
+            resp = HTTPForbidden(CSRF_ERR)
+
+        resp = self.add_new_token(resp)
         return resp(environ, start_response)
 
     def is_valid(self, request):
@@ -68,7 +77,14 @@ class CSRFMiddleware(object):
         if token is None:
             # Just in case this is set by an AJAX request
             token = request.cookies.get('X-CSRFToken', None)
-        return compare_digest(token, self.cache.get(self.session.id))
+        
+        csrf_token = self.cache.get(self.session.id)
+
+        if csrf_token == None:
+            log.warning('Could not find a csrf token for session id: {}\n{}'.format(self.session.id, request))
+            return False
+
+        return compare_digest(str(token), str(csrf_token))
 
     def add_new_token(self, response):
         token = codecs.encode(os.urandom(32), 'hex')

--- a/ckanext/security/middleware.py
+++ b/ckanext/security/middleware.py
@@ -4,7 +4,7 @@ import codecs
 import webob
 from webob.exc import HTTPForbidden
 
-from ckanext.security.cache.clients import MemcachedCSRFClient
+from ckanext.security.cache.clients import CSRFClient
 
 try:
     from hmac import compare_digest
@@ -42,7 +42,7 @@ class CSRFMiddleware(object):
 
     def __init__(self, app, config):
         self.app = app
-        self.cache = MemcachedCSRFClient()
+        self.cache = CSRFClient()
         self.domain = config['ckanext.security.domain']
 
     def __call__(self, environ, start_response):

--- a/ckanext/security/middleware.py
+++ b/ckanext/security/middleware.py
@@ -62,7 +62,8 @@ class CSRFMiddleware(object):
         else:
             resp = HTTPForbidden(CSRF_ERR)
 
-        resp = self.add_new_token(resp)
+        if 'text/html' in resp.headers['Content-type']:
+            resp = self.add_new_token(resp)
         return resp(environ, start_response)
 
     def is_valid(self, request):

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '1.0.1'
+version = '1.1.0'
 
 setup(
     name='ckanext-security',

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     zip_safe=False,
     install_requires=[
         'repoze.who-use-beaker',
-        'pylibmc'
+        'redis'
     ],
     dependency_links=[
         'git+https://github.com/kaukas/repoze.who-use_beaker.git@8ec4cea#egg=repoze.who-use-beaker-0.4'

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ setup(
     zip_safe=False,
     install_requires=[
         'repoze.who-use-beaker',
-        'redis'
+        'redis',
+        'beakeredis'
     ],
     dependency_links=[
         'git+https://github.com/kaukas/repoze.who-use_beaker.git@8ec4cea#egg=repoze.who-use-beaker-0.4'


### PR DESCRIPTION
Includes changes to support moving from memcache to redis, and support for ckan 2.7.

Original PR for redis support: https://github.com/data-govt-nz/ckanext-security/pull/16


### Todo before release

- [x] bump version
- [x] re-enable fix for race condition on the csrf token.
- [x] test security plugin features
- [x] test csrf feaatures