### PR TITLE
Handle http request without content-type

### DIFF
--- a/ckanext/security/middleware.py
+++ b/ckanext/security/middleware.py
@@ -62,8 +62,9 @@ class CSRFMiddleware(object):
         else:
             resp = HTTPForbidden(CSRF_ERR)
 
-        if 'text/html' in resp.headers['Content-type']:
+        if 'text/html' in resp.headers.get('Content-type', ''):
             resp = self.add_new_token(resp)
+
         return resp(environ, start_response)
 
     def is_valid(self, request):


### PR DESCRIPTION
A well formed http request should have a `Content-type` header, but when
the content-type is not defined, it will cause our security middleware
to throw a keyerror.

This change makes sure that an error is not thrown in this case. When
there is no content-type header, the token will not be refreshed