### PR TITLE
Update/brute force lockout by account

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,13 @@ Reset tokens are generated using `os.urandom(16)` instead of CKAN's default
 
 ### Brute force protection
 Users attempting to log in more than `ckanext.security.login_max_count` times
-within `ckanext.security.lock_timeout` seconds will be
-temporarily locked out.
+within `ckanext.security.lock_timeout` seconds will be temporarily locked out.
 
-By default, this means that after 10 unsuccessful login attempts within 15 minutes
+By default, this means that after 10 unsuccessful login attempts from the same IP address within 15 minutes
 the login will be disabled for another 15 minutes.
+
+Setting `ckanext.security.brute_force_key` to `user_name` will ignore the IP address so that unsuccessful login attempts will be detected
+based on user_name only. This provides greater security against attackers that can vary their IP address at the cost of the legitimate user getting locked out as well.
 
 A notification email will be sent to locked out users.
 
@@ -102,6 +104,7 @@ ckanext.security.redis.db = 1                 # ckan uses db 0
 # 15 minute timeout with 10 attempts
 ckanext.security.lock_timeout = 900           # Login throttling lock period
 ckanext.security.login_max_count = 10         # Login throttling attempt limit
+ckanext.security.brute_force_key = user_name  # Detect brute force attempts by username rather than IP address
 ```
 
 ## How to install?

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Reset tokens are generated using `os.urandom(16)` instead of CKAN's default
 
 ### Brute force protection
 Users attempting to log in more than `ckanext.security.login_max_count` times
-within `ckanext.security.lock_timeout` seconds from a single IP address will be
+within `ckanext.security.lock_timeout` seconds will be
 temporarily locked out.
 
 By default, this means that after 10 unsuccessful login attempts within 15 minutes

--- a/ckanext/security/authenticator.py
+++ b/ckanext/security/authenticator.py
@@ -3,6 +3,7 @@ import logging
 from ckan.lib.authenticator import UsernamePasswordAuthenticator
 from ckan.lib.cli import MockTranslator
 from ckan.model import User
+from ckan.common import config
 import pylons
 from flask import abort
 from repoze.who.interfaces import IAuthenticator
@@ -13,6 +14,20 @@ from ckanext.security.model import SecurityTOTP, ReplayAttackException
 
 log = logging.getLogger(__name__)
 
+def get_request_ip_address(request):
+    """Retrieves the IP address from the request if possible"""
+    remote_addr = request.headers.get('X-Forwarded-For') or request.environ.get('REMOTE_ADDR')
+    if remote_addr == None:
+        log.critical('X-Forwarded-For header/REMOTE_ADDR missing from request.')
+
+    return remote_addr
+
+def get_login_throttle_key(request, user_name):
+    login_throttle_key = get_request_ip_address(request)
+    if config.get('ckanext.security.brute_force_key') == 'user_name':
+        login_throttle_key = user_name
+
+    return login_throttle_key
 
 class CKANLoginThrottle(UsernamePasswordAuthenticator):
     implements(IAuthenticator)
@@ -33,7 +48,11 @@ class CKANLoginThrottle(UsernamePasswordAuthenticator):
         # in every case and make timing attacks a little more difficult.
         auth_user_name = super(CKANLoginThrottle, self).authenticate(environ, identity)
 
-        throttle = LoginThrottle(User.by_name(user_name), user_name)
+        login_throttle_key = get_login_throttle_key(Request(environ), user_name)
+        if login_throttle_key is None:
+            return None
+
+        throttle = LoginThrottle(User.by_name(user_name), login_throttle_key)
         # Check if there is a lock on the requested user, and return None if
         # we have a lock.
         if throttle.is_locked():

--- a/ckanext/security/cache/login.py
+++ b/ckanext/security/cache/login.py
@@ -15,34 +15,30 @@ class LoginThrottle(object):
     login_lock_timeout = int(config.get('ckanext.security.lock_timeout', 60 * 15))
     login_max_count = int(config.get('ckanext.security.login_max_count', 10))
     count = 0
+    last_failed_attempt = 0
 
-    def __init__(self, user, remote_addr):
+    def __init__(self, user, key):
         self.request_time = time.time()
         self.user = user
         self.cli = ThrottleClient()
-        self.remote_addr = remote_addr
-
-        # Separately caching user name, because str(user) yields an unwieldy
-        # repr of the User class.
-        self.user_name = str(user) if user is None else user.name
+        self.key = key
 
     def _check_count(self):
         return self.count >= self.login_max_count
 
-    def _check_time(self, last_attempt):
+    def _check_time_since_last_attempt(self, last_attempt):
         return self.request_time - float(last_attempt) < self.login_lock_timeout
 
     def get(self):
-        value = self.cli.get(self.remote_addr)
+        value = self.cli.get(self.key)
         if value is not None:
             return json.loads(value)
         return {}
 
     def reset(self):
         value = self.get()
-        if self.user_name in value:
-            del value[self.user_name]
-        self.cli.set(self.remote_addr, json.dumps(value))
+        value['count'] = 0
+        self.cli.set(self.key, json.dumps(value))
 
     def increment(self):
         value = self.get()
@@ -51,24 +47,32 @@ class LoginThrottle(object):
         # the user would be locked out for another `login_lock_timeout` minutes
         # whenever he/she tries to login again.
         if self.count < self.login_max_count + 1:
-            value.update({self.user_name: "%s:%s" % (self.count + 1, self.request_time)})
-            self.cli.set(self.remote_addr, json.dumps(value))
+            value.update({
+                'count': self.count + 1,
+                'last_failed_attempt': self.request_time,
+            })
+            self.cli.set(self.key, json.dumps(value))
 
-    def needs_lockout(self, cache_value):
-        count, last_attempt = cache_value.split(':')
-        self.count = int(count) if self._check_time(last_attempt) else 0
-        if self._check_count():
-            if self.user is not None and self.count == self.login_max_count:
-                log.info("%s locked out by brute force protection" % self.user.name)
-                try:
-                    notify_lockout(self.user, self.remote_addr)
-                    log.debug("Lockout notification for user %s sent" % self.user.name)
-                except Exception as exc:
-                    msg = "Sending lockout notification for %s failed"
-                    log.exception(msg % self.user.name, exc_info=exc)
-            return False
+    def needs_lockout(self):
+        if self.user is not None and self.count == self.login_max_count:
+            log.info("%s locked out by brute force protection" % self.user.name)
+            try:
+                notify_lockout(self.user)
+                log.debug("Lockout notification for user %s sent" % self.user.name)
+            except Exception as exc:
+                msg = "Sending lockout notification for %s failed"
+                log.exception(msg % self.user.name, exc_info=exc)
+        return False
 
     def check_attempts(self):
-        cached = self.get().get(self.user_name, None)
-        if cached is not None:
-            return self.needs_lockout(cached)
+        value = self.get()
+        in_possible_lockout_window = self._check_time_since_last_attempt(value.get('last_failed_attempt', 0))
+        self.count = value.get('count', 0) if in_possible_lockout_window else 0
+        if self._check_count():
+            return self.needs_lockout()
+
+    def is_locked(self):
+        if self.check_attempts() is False:
+            self.increment()  # Increment so we only send an email the first time around
+            return True
+        return False

--- a/ckanext/security/mailer.py
+++ b/ckanext/security/mailer.py
@@ -30,11 +30,10 @@ def send_reset_link(user):
     mail_user(user, subject, body)
 
 
-def notify_lockout(user, locked_ip):
+def notify_lockout(user):
     extra_vars = {
         'site_title': config.get('ckan.site_title'),
         'site_url': config.get('ckan.site_url'),
-        'ip_address': locked_ip,
         'user_name': user.name,
     }
 

--- a/ckanext/security/templates/security/emails/lockout_mail.txt
+++ b/ckanext/security/templates/security/emails/lockout_mail.txt
@@ -2,8 +2,7 @@ Dear {{ user_name }},
 
 We have detected an unusually large amount of login attempts for your account.
 
-As a security precaution, we have temporarily blocked the IP address {{ ip_address }}
-from logging in with your credentials.
+As a security precaution, we have temporarily blocked your account.
 
 If you would like to reset your password, you can use the form provided on {{ site_url }}.
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '2.0.0'
+version = '2.1.0'
 
 setup(
     name='ckanext-security',


### PR DESCRIPTION
This PR represents a move away from tracking brute force login attempts based on IP address, to tracking per username instead.

During security auditing, it was found that brute force attacks could be continued if the IP address appeared to change (via manipulation of request headers).

Now if a username fails login more than 10 times in the configured period (15 mins by default), the account will be locked, regardless of what IP address triggered the attempts.

This PR also fixes an issue where the 2 factor authentication changes in PR #28 bypassed the brute force lockout mechanism as the username/password checking is now happening in an ajax controller action, not using the built in authentication mechanisms until both username/password and 2 factor auth have been validated.