### PR TITLE
Prevent resource uploads for certain file types

### DIFF
--- a/ckanext/security/plugin.py
+++ b/ckanext/security/plugin.py
@@ -1,13 +1,20 @@
+import logging
+
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 import ckan.logic.schema
+
 from ckanext.security.model import define_security_tables
 from ckanext.security import schema
+from ckanext.security.resource_upload_validator import validate_upload_type, validate_upload_presence
+
+log = logging.getLogger(__name__)
 
 class CkanSecurityPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IConfigurer)
     plugins.implements(plugins.IRoutes)
     plugins.implements(plugins.IBlueprint)
+    plugins.implements(plugins.IResourceController, inherit=True)
 
     def update_config(self, config):
         define_security_tables()  # map security models to db schema
@@ -46,3 +53,15 @@ class CkanSecurityPlugin(plugins.SingletonPlugin):
                        action='login')
 
         return urlmap
+
+    # BEGIN Hooks for IResourceController
+    def before_create(self, context, resource):
+        validate_upload_presence(resource)
+        validate_upload_type(resource)
+        pass
+
+    def before_update(self, context, current, resource):
+        validate_upload_presence(resource)
+        validate_upload_type(resource)
+        pass
+    # END Hooks for IResourceController

--- a/ckanext/security/resource_upload_validator.py
+++ b/ckanext/security/resource_upload_validator.py
@@ -1,0 +1,98 @@
+import mimetypes
+import magic
+import logging
+import os
+
+from ckan.logic import ValidationError
+from ckan.common import config
+
+log = logging.getLogger(__name__)
+
+DEFAULT_UPLOAD_BLACKLIST = ['.exe']
+DEFAULT_EXTENDED_UPLOAD_MIMETYPES = { 'application/x-dosexec': '.exe' }
+
+def _add_mimetypes():
+    if not mimetypes.inited:
+        mimetypes.init()
+
+    # Add mimetypes from config
+    config_mimetypes = eval(config.get('ckanext.security.extended_upload_mimetypes', '{}'))
+    extended_mimetypes = DEFAULT_EXTENDED_UPLOAD_MIMETYPES.copy()
+    extended_mimetypes.update(config_mimetypes) # merges defaults and config
+
+    for mime in extended_mimetypes:
+        mimetypes.add_type(mime, extended_mimetypes[mime], strict=False)
+
+def _build_mimetypes_and_extensions(filename, file_content):
+    mimes_instance = mimetypes.MimeTypes()
+    extensions_and_mimetypes = []
+
+    # get supplied file extension and possible mimetypes for that extension
+    _, supplied_file_extension = os.path.splitext(filename)
+    if supplied_file_extension:
+        extensions_and_mimetypes.append(supplied_file_extension)
+
+        guessed_mimetypes = filter(lambda type: type is not None, [
+            mimes_instance.types_map[0].get(supplied_file_extension),
+            mimes_instance.types_map[1].get(supplied_file_extension)
+        ])
+        extensions_and_mimetypes.extend(guessed_mimetypes)
+
+    if file_content:
+        # get inferred mimetype of file and possible extensions for that mimetype
+        try:
+            # try to get python-magic to infer upload file mime type from actual file content
+            mimetype = magic.from_buffer(file_content.read(2048), mime=True)
+        except IOError:
+            log.warning('Unable to detect mimetype from file content')
+
+        if mimetype:
+            extensions_and_mimetypes.append(mimetype)
+
+            # build set of possible extensions for the mimetype
+            nonstandard_extensions = mimes_instance.types_map_inv[0].get(mimetype, [])
+            standard_extensions = mimes_instance.types_map_inv[1].get(mimetype, [])
+            extensions_and_mimetypes.extend(nonstandard_extensions)
+            extensions_and_mimetypes.extend(standard_extensions)
+
+    unique_set = set(extensions_and_mimetypes)
+    unique_list = list(unique_set)
+
+    return unique_list
+
+def validate_upload_type(resource):
+    """
+    Uses the mimetypes builtin library to make inferences about the filename
+def _get_linked_file(url):
+    and test the possible mimetypes and extensions against the blacklist.
+    Also uses python-magic to attempt detection of the mimetype by file contents.
+
+    NOTE: When linking files rather than uploading, we only test the extension at present.
+    """
+    try:
+        uploaded_file = resource.get('upload').file
+    except AttributeError:
+        uploaded_file = None
+
+    _add_mimetypes()
+    extensions_and_mimetypes = _build_mimetypes_and_extensions(resource.get('url'), uploaded_file)
+
+    config_blacklist = eval(config.get('ckanext.security.upload_blacklist', '[]'))
+    blacklist = list(DEFAULT_UPLOAD_BLACKLIST)
+    blacklist.extend(config_blacklist)
+
+    log.info('Detected extensions/mimetypes: {}'.format(extensions_and_mimetypes))
+    # test all extensions and mimetypes against blacklist, fail fast
+    if any(map(lambda ext: ext in blacklist, extensions_and_mimetypes)):
+        log.warning('Prevented upload of {}, detected mimetypes/extensions: {}, blacklist: {}'.format(resource.get('url'), extensions_and_mimetypes, blacklist))
+        resource['url'] = ''
+        action = 'upload' if uploaded_file else 'link'
+        raise ValidationError(
+            {'File': ['Cannot {} files of this type'.format(action)]}
+        )
+
+def validate_upload_presence(resource):
+    if not resource.get('url'):
+        raise ValidationError(
+            {'File': ['Please upload a file or link to an external resource']}
+        )

--- a/ckanext/security/resource_upload_validator.py
+++ b/ckanext/security/resource_upload_validator.py
@@ -60,6 +60,13 @@ def _build_mimetypes_and_extensions(filename, file_content):
 
     return unique_list
 
+def _get_uploaded_file(resource):
+    try:
+        uploaded_file = resource.get('upload').file
+    except AttributeError:
+        uploaded_file = None
+    return uploaded_file
+
 def validate_upload_type(resource):
     """
     Uses the mimetypes builtin library to make inferences about the filename
@@ -68,10 +75,7 @@ def validate_upload_type(resource):
 
     NOTE: When linking files rather than uploading, we only test the extension at present.
     """
-    try:
-        uploaded_file = resource.get('upload').file
-    except AttributeError:
-        uploaded_file = None
+    uploaded_file = _get_uploaded_file(resource)
 
     _add_mimetypes()
     extensions_and_mimetypes = _build_mimetypes_and_extensions(resource.get('url'), uploaded_file)
@@ -91,7 +95,8 @@ def validate_upload_type(resource):
         )
 
 def validate_upload_presence(resource):
-    if not resource.get('url'):
+    linked_or_uploaded = bool(resource.get('url')) or _get_uploaded_file(resource) is not None
+    if not linked_or_uploaded:
         raise ValidationError(
             {'File': ['Please upload a file or link to an external resource']}
         )

--- a/ckanext/security/resource_upload_validator.py
+++ b/ckanext/security/resource_upload_validator.py
@@ -63,7 +63,6 @@ def _build_mimetypes_and_extensions(filename, file_content):
 def validate_upload_type(resource):
     """
     Uses the mimetypes builtin library to make inferences about the filename
-def _get_linked_file(url):
     and test the possible mimetypes and extensions against the blacklist.
     Also uses python-magic to attempt detection of the mimetype by file contents.
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '2.1.0'
+version = '2.2.0'
 
 setup(
     name='ckanext-security',

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,8 @@ setup(
         'repoze.who-use-beaker',
         'redis',
         'beakeredis',
-        'pyotp'
+        'pyotp',
+        'python-magic'
     ],
     dependency_links=[
         'git+https://github.com/kaukas/repoze.who-use_beaker.git@8ec4cea#egg=repoze.who-use-beaker-0.4'


### PR DESCRIPTION
This feature tightens up the types of allowed files for resource uploads by excluding .exe files.

It provides user feedback if the uploaded file is blacklisted.

See README changes for more information.

![Screenshot from 2020-04-23 14-12-55](https://user-images.githubusercontent.com/1121256/80051636-c5d11e80-856c-11ea-8b2b-a166285c2e3c.png)

![Screenshot from 2020-04-23 14-13-23](https://user-images.githubusercontent.com/1121256/80051643-cb2e6900-856c-11ea-99f2-04968dc65689.png)
