### PR TITLE
Update/allow password reset disabling

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ or [commit `74f78865`](https://github.com/data-govt-nz/ckan/commit/74f78865b8825
 * A running Redis instance to store brute force protection tokens configured with a maxmemory and maxmemory-policy=lru so it overwrites the least recently used item rather than running out of space. This instance should be a different instance from the one used for Harvest items to avoid data loss. [Redis LRU-Cache documentation](https://redis.io/topics/lru-cache).
 
 ### Changes to `who.ini`
-You will need at least the following setting ins your `who.ini`
+You will need at least the following setting in your `who.ini`
 
 ```ini
 [plugin:use_beaker]
@@ -141,6 +141,11 @@ ckanext.security.redis.db = 1                 # ckan uses db 0
 ckanext.security.lock_timeout = 900           # Login throttling lock period
 ckanext.security.login_max_count = 10         # Login throttling attempt limit
 ckanext.security.brute_force_key = user_name  # Detect brute force attempts by username rather than IP address
+
+# If using 2.7.7 or recent patches of 2.8, the password reset behaviour has been fixed in CKAN core
+# (no longer discloses info about non-existent accounts)
+# You can disable the fix in this plugin by:
+ckanext.security.disable_password_reset_override = true
 ```
 
 ## How to install?

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ disclose whether or not that email address exists in the DB
 * Two Factor Authentication is enforced for all users
 * Preventing upload/linking of certain file types for resources
 
+**Please note**: This extension has been used and tested against CKAN version 2.7.x. Using it in the context of CKAN 2.8 or higher versions may not work fully. If you are wanting to use this extension in other CKAN versions and you do strike issues, the maintainers would be happy to accept contributions to fix anything you find. Please raise an issue or open a pull request.
+
 ### Reset tokens
 Reset tokens are generated using `os.urandom(16)` instead of CKAN's default
 `uuid.uuid4().hex[:10]`.
@@ -143,7 +145,8 @@ ckanext.security.login_max_count = 10         # Login throttling attempt limit
 ckanext.security.brute_force_key = user_name  # Detect brute force attempts by username rather than IP address
 
 # If using 2.7.7 or recent patches of 2.8, the password reset behaviour has been fixed in CKAN core
-# (no longer discloses info about non-existent accounts)
+# (no longer discloses info about non-existent accounts) and the way this plugin overrides the password
+# reset may be broken due to permission restrictions on user lookups,
 # You can disable the fix in this plugin by:
 ckanext.security.disable_password_reset_override = true
 ```

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '2.2.0'
+version = '2.3.0'
 
 setup(
     name='ckanext-security',


### PR DESCRIPTION
Adds a config flag to allow disabling the monkey-patch for password reset behaviour. CKAN core has fixed the disclosing of accounts that don't exist when resetting passwords in more recent versions of CKAN, so not all clients of this plugin will need that feature anymore.