### PR TITLE
Fix/password reset token regression

### DIFF
--- a/ckanext/security/controllers.py
+++ b/ckanext/security/controllers.py
@@ -6,14 +6,14 @@ from ckan import authz, model
 from ckan.common import _, c, request, config
 from ckan.controllers.user import UserController
 from ckan.lib.base import abort, render
-from ckan.lib import helpers
+from ckan.lib import helpers, mailer
 from ckan.lib.navl.dictization_functions import Invalid
 from ckan.logic import schema, NotAuthorized, check_access, get_action, NotFound
 from ckan.plugins import toolkit as tk
 from paste.deploy.converters import asbool
 
 from ckanext.security.authenticator import get_login_throttle_key
-from ckanext.security import mailer
+import ckanext.security.mailer as secure_mailer
 from ckanext.security.validators import old_username_validator
 from ckanext.security.model import SecurityTOTP
 from ckanext.security.cache.login import LoginThrottle
@@ -168,7 +168,7 @@ class MFAUserController(tk.BaseController):
         helpers.flash_success(_('Successfully updated two factor authentication secret. Make sure you add the new secret to your authenticator app.'))
         helpers.redirect_to('mfa_configure', id=user_id)
 
-
+mailer.send_reset_link = secure_mailer.send_reset_link
 original_password_reset = UserController.request_reset
 class SecureUserController(UserController):
     edit_user_form = 'security/edit_user_form.html'

--- a/ckanext/security/controllers.py
+++ b/ckanext/security/controllers.py
@@ -200,7 +200,8 @@ class SecureUserController(UserController):
             id = request.params.get('user')
 
             context = {'model': model,
-                       'user': c.user}
+                       'user': c.user,
+                       u'ignore_auth': True}
 
             data_dict = {'id': id}
             user_obj = None

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '2.3.0'
+version = '2.3.1'
 
 setup(
     name='ckanext-security',


### PR DESCRIPTION
Version 2.3.0 introduced an issue where if you used the config option to remove the password reset override (fixed in later versions of CKAN, see #32 ) then the password reset token length regressed to CKAN defaults as well.

This work changes the password reset override to monkeypatch the longer reset token method onto the CKAN core mailer, making it possible to still use the core password reset functionality.