### PR TITLE
Update/protect against 2fa brute force

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ within `ckanext.security.lock_timeout` seconds will be temporarily locked out.
 By default, this means that after 10 unsuccessful login attempts from the same IP address within 15 minutes
 the login will be disabled for another 15 minutes.
 
+Failed two factor authentication code attempts are included in the count of unsuccessful login attempts. For example, five failed username and password attempts and then five failed 2fa codes will trigger the brute force lockout.
+
 Setting `ckanext.security.brute_force_key` to `user_name` will ignore the IP address so that unsuccessful login attempts will be detected
 based on user_name only. This provides greater security against attackers that can vary their IP address at the cost of the legitimate user getting locked out as well.
 
@@ -39,6 +41,7 @@ The path can be provided via the `ckanext.security.brute_force_footer_path` conf
 Users are required to use Two Factor Authentication (2fa). This feature adds a two step login flow, where the user adds their username and password first, then their 2fa code after. They are presented with a QR code to configure an authentication app on first login, then just an input for the one-time code on subsequent logins.
 
 A configuration interface is provided so that the user may reset their 2fa secret if needed, and sysadmins may use this facility to reset a locked out user.
+
 A paster command is also provided for resetting a users 2fa secret from the commandline on the server:
 ```shell
 paster --plugin=ckanext-security security reset_totp <username>

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Users are required to use Two Factor Authentication (2fa). This feature adds a t
 
 A configuration interface is provided so that the user may reset their 2fa secret if needed, and sysadmins may use this facility to reset a locked out user.
 
-A paster command is also provided for resetting a users 2fa secret from the commandline on the server:
+A paster command is also provided for resetting a user's 2fa secret from the commandline on the server:
 ```shell
 paster --plugin=ckanext-security security reset_totp <username>
 ```

--- a/ckanext/security/controllers.py
+++ b/ckanext/security/controllers.py
@@ -93,6 +93,8 @@ class MFAUserController(tk.BaseController):
                 tk.response.status_int = 422
                 return json.dumps(res)
 
+            on_mfa_form = identity.get('mfa-form-active') == 'true'
+
             user_name = identity['login']
             user = model.User.by_name(user_name)
 
@@ -111,8 +113,8 @@ class MFAUserController(tk.BaseController):
                 # Increment the throttle counter if the login failed.
                 throttle.increment()
 
-            if invalid_login or (invalid_login and locked_out):
-                log.info('login failed for {}'.format(user_name))
+            if invalid_login or (locked_out and not on_mfa_form):
+                log.info('login failed for %s', user_name)
                 tk.response.status_int = 403
                 return json.dumps(res)
 

--- a/ckanext/security/controllers.py
+++ b/ckanext/security/controllers.py
@@ -106,7 +106,7 @@ class MFAUserController(tk.BaseController):
             throttle = LoginThrottle(user, login_throttle_key)
             locked_out = throttle.is_locked()
             if locked_out:
-                log.info('User {} attempted login while brute force lockout in place'.format(user_name))
+                log.info('User %s attempted login while brute force lockout in place', user_name)
 
             invalid_login = user is None or not user.is_active() or not user.validate_password(identity['password'])
             if invalid_login:
@@ -134,15 +134,15 @@ class MFAUserController(tk.BaseController):
                 code_valid = totp_challenger.check_code(identity['mfa'], verify_only=True)
                 res['mfaCodeValid'] = code_valid and not locked_out
                 if code_valid:
-                    log.info('Login succeeded for {}'.format(user_name))
+                    log.info('Login succeeded for %s', user_name)
                 else:
-                    log.info('User {} supplied invalid 2fa code'.format(user_name))
+                    log.info('User %s supplied invalid 2fa code', user_name)
                     throttle.increment()
 
             return json.dumps(res)
 
         except Exception as err:
-            log.error('Unhandled error during login: {}'.format(err))
+            log.error('Unhandled error during login: %s', err)
             tk.response.status_int = 500
             return json.dumps({})
 

--- a/ckanext/security/fanstatic/login_ajax.js
+++ b/ckanext/security/fanstatic/login_ajax.js
@@ -64,6 +64,7 @@
     $('#login-form').hide()
     $('#mfa-form').show()
     $('#field-mfa').focus()
+    $('#mfa-form-active').val('true')
 
     if (!loginState.mfaConfigured) {
       showQRCode(loginState)

--- a/ckanext/security/templates/user/snippets/login_form.html
+++ b/ckanext/security/templates/user/snippets/login_form.html
@@ -55,6 +55,7 @@ overrides rendering of the login form
     <p>{{_('Please enter your authenticator app generated 6-digit verification code.')}}</p>
     {{ form.input('mfa', label=_("Verification code"), id='field-mfa', type="text", value="", error=mfa_error, classes=["control-medium"], attrs={"autocomplete": "off"}) }}
 
+    <input id="mfa-form-active" name="mfa-form-active" type="hidden" value="" />
     <div class="form-actions">
       <button class="btn btn-primary" type="submit">{{ _('Submit') }}</button>
     </div>

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '2.4.1'
+version = '2.4.2'
 
 setup(
     name='ckanext-security',


### PR DESCRIPTION
This work rolls the 2fa code attempts into the total count of failed attempts for brute force protection. Previously the ajax call to test the code could be made any number of times, potentially allowing a brute force attack on the 2fa code if an attacker had gained the correct username/password for an account.