### PR TITLE
Use /api path for ajax login call

### DIFF
--- a/ckanext/security/fanstatic/login_ajax.js
+++ b/ckanext/security/fanstatic/login_ajax.js
@@ -27,13 +27,14 @@
 
   var validateLoginCredentials = function (e) {
     e.preventDefault()
+    hideError()
 
     var form = $(this)
     var buttons = $('[type=submit]')
     buttons.prop('disabled', true)
 
     $.ajax({
-      url: '/mfa_login',
+      url: '/api/mfa_login',
       method: 'POST',
       data: form.serialize(),
       success: function (loginState) {

--- a/ckanext/security/plugin.py
+++ b/ckanext/security/plugin.py
@@ -48,7 +48,7 @@ class CkanSecurityPlugin(plugins.SingletonPlugin):
         urlmap.connect('mfa_configure', '/configure_mfa/{id:.*}',
                        controller=controller,
                        action='configure_mfa')
-        urlmap.connect('/mfa_login',
+        urlmap.connect('/api/mfa_login',
                        controller=controller,
                        action='login')
 


### PR DESCRIPTION
CKAN has special response middleware that overrides
the content/body of the response for certain status
codes. However, it does not apply on routes under
the /api paths so we can make sure the response type
can be consistently json regardless of the status
code.