### PR TITLE
API for throttle control, reset user throttle on update

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ A notification email will be sent to locked out users.
 The email footer content can be overridden by providing a path to a file that will replace the content in `templates/security/emails/lockout_footer.txt` in this module.
 The path can be provided via the `ckanext.security.brute_force_footer_path` config option.
 
+Sysadmins may use the `security_throttle_user_show` or `security_throttle_address_show` actions to query the brute force lockout status for a username or IP address. The `security_throttle_user_reset` and `security_throttle_address_reset` actions may be used to clear a brute force lockout status before the configured timeout.
+
+Lockouts are removed automatically when a user's password is reset or their account is modified.
+
 ### Two Factor Authentication enforcement
 Users are required to use Two Factor Authentication (2fa). This feature adds a two step login flow, where the user adds their username and password first, then their 2fa code after. They are presented with a QR code to configure an authentication app on first login, then just an input for the one-time code on subsequent logins.
 

--- a/ckanext/security/authenticator.py
+++ b/ckanext/security/authenticator.py
@@ -29,6 +29,31 @@ def get_login_throttle_key(request, user_name):
 
     return login_throttle_key
 
+
+def get_user_throttle(user_name):
+    if config.get('ckanext.security.brute_force_key') != 'user_name':
+        return {}
+    return LoginThrottle(User.by_name(user_name), user_name).get()
+
+
+def get_address_throttle(address):
+    if config.get('ckanext.security.brute_force_key') == 'user_name':
+        return {}
+    return LoginThrottle(None, address).get()
+
+
+def reset_user_throttle(user_name):
+    if config.get('ckanext.security.brute_force_key') != 'user_name':
+        return
+    LoginThrottle(User.by_name(user_name), user_name).reset()
+
+
+def reset_address_throttle(address):
+    if config.get('ckanext.security.brute_force_key') == 'user_name':
+        return
+    LoginThrottle(None, address).reset()
+
+
 class CKANLoginThrottle(UsernamePasswordAuthenticator):
     implements(IAuthenticator)
 

--- a/ckanext/security/logic/action.py
+++ b/ckanext/security/logic/action.py
@@ -1,0 +1,68 @@
+from ckan.plugins.toolkit import (
+    get_action,
+    chained_action,
+    check_access, get_or_bust, ValidationError)
+from ckan.model import User
+
+from ckanext.security.authenticator import (
+    get_user_throttle,
+    get_address_throttle,
+    reset_user_throttle,
+    reset_address_throttle,
+)
+
+
+def security_throttle_user_reset(context, data_dict):
+    """
+    Reset throttling information for a user, allowing logins
+
+    address: user name
+    """
+    check_access('security_throttle_user_reset', context, data_dict)
+    user = get_or_bust(data_dict, 'user')
+    return reset_user_throttle(user)
+
+
+def security_throttle_address_reset(context, data_dict):
+    """
+    Reset throttling information for an address, allowing logins
+
+    address: IP address
+    """
+    check_access('security_throttle_address_reset', context, data_dict)
+    address = get_or_bust(data_dict, 'address')
+    return reset_address_throttle(address)
+
+
+def security_throttle_user_show(context, data_dict):
+    """
+    Retrieve the throttling information for a user
+
+    user: user name
+    """
+    check_access('security_throttle_user_show', context, data_dict)
+    user = get_or_bust(data_dict, 'user')
+    return get_user_throttle(user)
+
+
+def security_throttle_address_show(context, data_dict):
+    """
+    Retrieve the throttling information for an IP address
+
+    address: IP address
+    """
+    check_access('security_throttle_address_show', context, data_dict)
+    address = get_or_bust(data_dict, 'address')
+    return get_address_throttle(address)
+
+
+@chained_action
+def user_update(up_func, context, data_dict):
+    """
+    ckanext-security: reset throttling information for updated users
+    to allow new login attempts after password reset
+    """
+    rval = up_func(context, data_dict)
+    get_action('security_throttle_user_reset')(
+        dict(context, ignore_auth=True), {'user': rval['name']})
+    return rval

--- a/ckanext/security/logic/auth.py
+++ b/ckanext/security/logic/auth.py
@@ -1,0 +1,15 @@
+'''
+Action functions, all sysadmin-only
+'''
+
+def security_throttle_user_reset(context, data_dict):
+    return {'success': False}
+
+def security_throttle_address_reset(context, data_dict):
+    return {'success': False}
+
+def security_throttle_user_show(context, data_dict):
+    return {'success': False}
+
+def security_throttle_address_show(context, data_dict):
+    return {'success': False}

--- a/ckanext/security/plugin.py
+++ b/ckanext/security/plugin.py
@@ -7,6 +7,7 @@ import ckan.logic.schema
 from ckanext.security.model import define_security_tables
 from ckanext.security import schema
 from ckanext.security.resource_upload_validator import validate_upload_type, validate_upload_presence
+from ckanext.security.logic import auth, action
 
 log = logging.getLogger(__name__)
 
@@ -15,6 +16,8 @@ class CkanSecurityPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IRoutes)
     plugins.implements(plugins.IBlueprint)
     plugins.implements(plugins.IResourceController, inherit=True)
+    plugins.implements(plugins.IActions)
+    plugins.implements(plugins.IAuthFunctions)
 
     def update_config(self, config):
         define_security_tables()  # map security models to db schema
@@ -65,3 +68,24 @@ class CkanSecurityPlugin(plugins.SingletonPlugin):
         validate_upload_type(resource)
         pass
     # END Hooks for IResourceController
+
+    # BEGIN Hooks for IActions
+    def get_actions(self):
+        return {
+            'security_throttle_user_reset': action.security_throttle_user_reset,
+            'security_throttle_address_reset': action.security_throttle_address_reset,
+            'security_throttle_user_show': action.security_throttle_user_show,
+            'security_throttle_address_show': action.security_throttle_address_show,
+            'user_update': action.user_update,
+        }
+    # END Hooks for IActions
+
+    # BEGIN Hooks for IAuthFunctions
+    def get_auth_functions(self):
+        return {
+            'security_throttle_user_reset': auth.security_throttle_user_reset,
+            'security_throttle_address_reset': auth.security_throttle_address_reset,
+            'security_throttle_user_show': auth.security_throttle_user_show,
+            'security_throttle_address_show': auth.security_throttle_address_show,
+        }
+    # END Hooks for IAuthFunctions

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         'repoze.who-use-beaker',
         'redis',
         'beakeredis',
-        'pyotp',
+        'pyotp<2.4.0',
         'python-magic'
     ],
     dependency_links=[


### PR DESCRIPTION
- Add actions to query and reset throttle controls (sysadmin-only)
- Reset user lockout when their record is updated, e.g. on a successful password reset
- fix pyotp dependency for Python 2