### PR TITLE
DATA-860 2fa reset link

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,10 @@ ckanext.security.brute_force_key = user_name  # Detect brute force attempts by u
 # reset may be broken due to permission restrictions on user lookups,
 # You can disable the fix in this plugin by:
 ckanext.security.disable_password_reset_override = true
+
+# Provide a help page to allow 2fa users to contact support or get more information
+# Shows up as 'Need help?' on the 2fa entry form beside the submit button. Does not display a link if none provided
+ckanext.security.mfa_help_link = https://data.govt.nz/catalogue-guide/releasing-data-on-data-govt-nz/how-do-i-set-up-two-factor-authentication/
 ```
 
 ## How to install?

--- a/ckanext/security/controllers.py
+++ b/ckanext/security/controllers.py
@@ -134,6 +134,9 @@ class MFAUserController(tk.BaseController):
             res['mfaConfigured'] = mfaConfigured
             set_response(200)
 
+            if config.get('ckanext.security.mfa_help_link') is not None:
+                res['mfaHelpLink'] = config.get('ckanext.security.mfa_help_link')
+
             if identity['mfa']:
                 code_valid = totp_challenger.check_code(identity['mfa'], verify_only=True)
                 res['mfaCodeValid'] = code_valid and not locked_out

--- a/ckanext/security/fanstatic/login_ajax.js
+++ b/ckanext/security/fanstatic/login_ajax.js
@@ -48,17 +48,17 @@
         showMfaForm(loginState)
       },
       error: function (xhr) {
-        var jsonResponse = null;
-        try {
-          jsonResponse = JSON.parse(xhr.responseText)
-        } catch (e) {}
-
-        if (jsonResponse && jsonResponse.hasOwnProperty('mfaCodeValid')) {
-          showError('mfa')
-          return
-        }
-
         if (xhr.status === 403) {
+          // Show MFA error message if mfa code is not valid
+          try {
+            var jsonResponse = JSON.parse(xhr.responseText)
+            if (jsonResponse && jsonResponse.mfaCodeValid === false) {
+              showError('mfa')
+              return
+            }
+          } catch (e) {}
+
+          // Otherwise we're on the username/password form, show error for that
           showError('login')
           return
         }

--- a/ckanext/security/fanstatic/login_ajax.js
+++ b/ckanext/security/fanstatic/login_ajax.js
@@ -80,6 +80,11 @@
     if (!loginState.mfaConfigured) {
       showQRCode(loginState)
     }
+
+    if (loginState.mfaHelpLink) {
+      $('#mfa-help-link').attr('href', loginState.mfaHelpLink)
+      $('#mfa-help-link').show()
+    }
   }
 
   var showError = function (type) {

--- a/ckanext/security/fanstatic/login_ajax.js
+++ b/ckanext/security/fanstatic/login_ajax.js
@@ -48,6 +48,16 @@
         showMfaForm(loginState)
       },
       error: function (xhr) {
+        var jsonResponse = null;
+        try {
+          jsonResponse = JSON.parse(xhr.responseText)
+        } catch (e) {}
+
+        if (jsonResponse && jsonResponse.hasOwnProperty('mfaCodeValid')) {
+          showError('mfa')
+          return
+        }
+
         if (xhr.status === 403) {
           showError('login')
           return

--- a/ckanext/security/templates/user/snippets/login_form.html
+++ b/ckanext/security/templates/user/snippets/login_form.html
@@ -57,6 +57,7 @@ overrides rendering of the login form
 
     <input id="mfa-form-active" name="mfa-form-active" type="hidden" value="" />
     <div class="form-actions">
+      <a id="mfa-help-link" href="/" style="display: none; margin-right: 20px;">{{_('Need help?')}}</a>
       <button class="btn btn-primary" type="submit">{{ _('Submit') }}</button>
     </div>
   </div>

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '2.4.2'
+version = '2.5.0'
 
 setup(
     name='ckanext-security',


### PR DESCRIPTION
This little config addon allows you to specify a help page with useful information about how to set up and manage 2fa logins. This could be a useful place to detail your 2fa reset process if a user has lost their auth device.