### PR TITLE
Add an action to allow the resetting of users totp.

### DIFF
--- a/ckanext/security/authenticator.py
+++ b/ckanext/security/authenticator.py
@@ -60,6 +60,10 @@ def reset_address_throttle(address):
     LoginThrottle(None, address).reset()
 
 
+def reset_totp(user_name):
+    SecurityTOTP.create_for_user(user_name)
+
+
 class CKANLoginThrottle(UsernamePasswordAuthenticator):
     p.implements(p.IAuthenticator)
 

--- a/ckanext/security/logic/action.py
+++ b/ckanext/security/logic/action.py
@@ -7,6 +7,7 @@ from ckanext.security.authenticator import (
     get_address_throttle,
     reset_user_throttle,
     reset_address_throttle,
+    reset_totp
 )
 
 
@@ -52,6 +53,12 @@ def security_throttle_address_show(context, data_dict):
     check_access('security_throttle_address_show', context, data_dict)
     address = get_or_bust(data_dict, 'address')
     return get_address_throttle(address)
+
+
+def security_reset_totp(context, data_dict):
+    check_access('security_reset_totp', context, data_dict)
+    user = get_or_bust(data_dict, 'user')
+    return reset_totp(user)
 
 
 @chained_action

--- a/ckanext/security/logic/auth.py
+++ b/ckanext/security/logic/auth.py
@@ -13,3 +13,6 @@ def security_throttle_user_show(context, data_dict):
 
 def security_throttle_address_show(context, data_dict):
     return {'success': False}
+
+def security_reset_totp(context, data_dict):
+    return {'success': False}

--- a/ckanext/security/plugin/__init__.py
+++ b/ckanext/security/plugin/__init__.py
@@ -76,6 +76,8 @@ class CkanSecurityPlugin(MixinPlugin, p.SingletonPlugin):
                 action.security_throttle_user_show,
             'security_throttle_address_show':
                 action.security_throttle_address_show,
+            'security_reset_totp':
+                action.security_reset_totp,
             'user_update':
                 action.user_update,
         }
@@ -93,6 +95,8 @@ class CkanSecurityPlugin(MixinPlugin, p.SingletonPlugin):
                 auth.security_throttle_user_show,
             'security_throttle_address_show':
                 auth.security_throttle_address_show,
+            'security_reset_totp':
+                auth.security_reset_totp,
         }
     # END Hooks for IAuthFunctions
 


### PR DESCRIPTION
In working through the tests for our main repo I found that they where slowed down a lot by having to use the ckan cli to reset TOTP codes. To attempt to speed this up I have added a reset action for the TOTP codes. I think there was a suggestion somewhere to add this functionality but I can't recall where it was.