### PR TITLE
Disable totp authentication, if needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,10 @@ ckanext.security.brute_force_key = user_name      # Detect brute force attempts 
 # You can disable the fix in this plugin by:
 ckanext.security.disable_password_reset_override = true
 
+# Two factor authentication is enabled for all users by default
+# optional configuration to disable 2fa
+ckanext.security.disable_totp = false         # set to true to disable 2fa 
+
 # Provide a help page to allow 2fa users to contact support or get more information
 # Shows up as 'Need help?' on the 2fa entry form beside the submit button. Does not display a link if none provided
 ckanext.security.mfa_help_link = https://data.govt.nz/catalogue-guide/releasing-data-on-data-govt-nz/how-do-i-set-up-two-factor-authentication/

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ ckanext.security.disable_password_reset_override = true
 
 # Two factor authentication is enabled for all users by default
 # optional configuration to disable 2fa
-ckanext.security.disable_totp = false         # set to true to disable 2fa 
+ckanext.security.enable_totp = true         # set to false to disable 2fa 
 
 # Provide a help page to allow 2fa users to contact support or get more information
 # Shows up as 'Need help?' on the 2fa entry form beside the submit button. Does not display a link if none provided

--- a/ckanext/security/authenticator.py
+++ b/ckanext/security/authenticator.py
@@ -4,8 +4,9 @@ import logging
 from ckan.lib.authenticator import default_authenticate
 from ckan.model import User
 import ckan.plugins as p
-from ckan.plugins.toolkit import request, asbool, config
+from ckan.plugins.toolkit import request, config
 from ckanext.security.cache.login import LoginThrottle
+from ckanext.security.helpers import security_enable_totp
 from ckanext.security.model import SecurityTOTP, ReplayAttackException
 
 log = logging.getLogger(__name__)
@@ -89,7 +90,7 @@ def authenticate(identity):
     # totp authentication is enabled by default for all users
     # totp can be disabled, if needed, by setting
     # ckanext.security.enable_totp to false in configurations
-    if asbool(config.get('ckanext.security.enable_totp', True)):
+    if security_enable_totp():
         # if the CKAN authenticator has successfully authenticated
         # the request and the user wasn't locked out above,
         # then check the TOTP parameter to see if it is valid

--- a/ckanext/security/authenticator.py
+++ b/ckanext/security/authenticator.py
@@ -3,12 +3,10 @@ import logging
 
 from ckan.lib.authenticator import default_authenticate
 from ckan.model import User
-from ckan.common import config
 import ckan.plugins as p
-from ckan.plugins.toolkit import request
+from ckan.plugins.toolkit import request, asbool, config
 from ckanext.security.cache.login import LoginThrottle
 from ckanext.security.model import SecurityTOTP, ReplayAttackException
-from paste.deploy.converters import asbool
 
 log = logging.getLogger(__name__)
 
@@ -91,9 +89,7 @@ def authenticate(identity):
     # totp authentication is enabled by default for all users
     # totp can be disabled, if needed, by setting
     # ckanext.security.enable_totp to false in configurations
-    if not asbool(config.get('ckanext.security.enable_totp', True)):
-        return ckan_auth_result
-    else:
+    if asbool(config.get('ckanext.security.enable_totp', True)):
         # if the CKAN authenticator has successfully authenticated
         # the request and the user wasn't locked out above,
         # then check the TOTP parameter to see if it is valid
@@ -103,6 +99,8 @@ def authenticate(identity):
             if totp_success:
                 throttle.reset()
                 return totp_success
+    else:
+        return ckan_auth_result
 
 
 def authenticate_totp(auth_user):

--- a/ckanext/security/authenticator.py
+++ b/ckanext/security/authenticator.py
@@ -90,8 +90,8 @@ def authenticate(identity):
 
     # totp authentication is enabled by default for all users
     # totp can be disabled, if needed, by setting
-    # ckanext.security.disable_totp to True in configurations
-    if asbool(config.get('ckanext.security.disable_totp', False)):
+    # ckanext.security.enable_totp to false in configurations
+    if not asbool(config.get('ckanext.security.enable_totp', True)):
         return ckan_auth_result
     else:
         # if the CKAN authenticator has successfully authenticated

--- a/ckanext/security/authenticator.py
+++ b/ckanext/security/authenticator.py
@@ -90,18 +90,19 @@ def authenticate(identity):
     # totp authentication is enabled by default for all users
     # totp can be disabled, if needed, by setting
     # ckanext.security.enable_totp to false in configurations
-    if security_enable_totp():
-        # if the CKAN authenticator has successfully authenticated
-        # the request and the user wasn't locked out above,
-        # then check the TOTP parameter to see if it is valid
-        if ckan_auth_result is not None:
-            totp_success = authenticate_totp(user_name)
-            # if TOTP was successful -- reset the log in throttle
-            if totp_success:
-                throttle.reset()
-                return totp_success
-    else:
+    if not security_enable_totp():
+        throttle.reset()
         return ckan_auth_result
+
+    # if the CKAN authenticator has successfully authenticated
+    # the request and the user wasn't locked out above,
+    # then check the TOTP parameter to see if it is valid
+    if ckan_auth_result is not None:
+        totp_success = authenticate_totp(user_name)
+        # if TOTP was successful -- reset the log in throttle
+        if totp_success:
+            throttle.reset()
+            return ckan_auth_result
 
 
 def authenticate_totp(auth_user):

--- a/ckanext/security/helpers.py
+++ b/ckanext/security/helpers.py
@@ -3,4 +3,4 @@ from paste.deploy.converters import asbool
 
 
 def security_disable_totp():
-    return asbool(config.get('ckanext.security.disable_totp'))
+    return asbool(config.get('ckanext.security.disable_totp', False))

--- a/ckanext/security/helpers.py
+++ b/ckanext/security/helpers.py
@@ -1,5 +1,4 @@
-from ckan.common import config
-from paste.deploy.converters import asbool
+from ckan.plugins.toolkit import asbool, config
 
 
 def security_enable_totp():

--- a/ckanext/security/helpers.py
+++ b/ckanext/security/helpers.py
@@ -2,5 +2,5 @@ from ckan.common import config
 from paste.deploy.converters import asbool
 
 
-def security_disable_totp():
-    return asbool(config.get('ckanext.security.disable_totp', False))
+def security_enable_totp():
+    return asbool(config.get('ckanext.security.enable_totp', True))

--- a/ckanext/security/helpers.py
+++ b/ckanext/security/helpers.py
@@ -1,0 +1,6 @@
+from ckan.common import config
+from paste.deploy.converters import asbool
+
+
+def security_disable_totp():
+    return asbool(config.get('ckanext.security.disable_totp'))

--- a/ckanext/security/plugin/__init__.py
+++ b/ckanext/security/plugin/__init__.py
@@ -9,7 +9,7 @@ from ckanext.security.resource_upload_validator import (
     validate_upload
 )
 from ckanext.security.logic import auth, action
-from ckanext.security.helpers import security_disable_totp
+from ckanext.security.helpers import security_enable_totp
 
 from ckanext.security.plugin.flask_plugin import MixinPlugin
 
@@ -105,5 +105,5 @@ class CkanSecurityPlugin(MixinPlugin, p.SingletonPlugin):
     def get_helpers(self):
         return {
             'check_ckan_version': tk.check_ckan_version,
-            'security_disable_totp': security_disable_totp,
+            'security_enable_totp': security_enable_totp,
         }

--- a/ckanext/security/plugin/__init__.py
+++ b/ckanext/security/plugin/__init__.py
@@ -9,6 +9,7 @@ from ckanext.security.resource_upload_validator import (
     validate_upload
 )
 from ckanext.security.logic import auth, action
+from ckanext.security.helpers import security_disable_totp
 
 from ckanext.security.plugin.flask_plugin import MixinPlugin
 
@@ -104,4 +105,5 @@ class CkanSecurityPlugin(MixinPlugin, p.SingletonPlugin):
     def get_helpers(self):
         return {
             'check_ckan_version': tk.check_ckan_version,
+            'security_disable_totp': security_disable_totp,
         }

--- a/ckanext/security/templates/user/edit_user_form.html
+++ b/ckanext/security/templates/user/edit_user_form.html
@@ -8,7 +8,7 @@
   {% endcall %}
 {% endif %}
 
-{% if not h.security_disable_totp() %}
+{% if h.security_enable_totp() %}
   <fieldset>
     <legend>{{_('Two factor authentication')}}</legend>
     {% link_for _('Manage two factor authentication'), controller='mfa_user', action='configure_mfa', id=data.id, class_='btn btn-default pull-left', icon='cog' %}

--- a/ckanext/security/templates/user/edit_user_form.html
+++ b/ckanext/security/templates/user/edit_user_form.html
@@ -8,8 +8,11 @@
   {% endcall %}
 {% endif %}
 
-<fieldset>
-  <legend>{{_('Two factor authentication')}}</legend>
-  {% link_for _('Manage two factor authentication'), controller='mfa_user', action='configure_mfa', id=data.id, class_='btn btn-default pull-left', icon='cog' %}
-</fieldset>
+{% if h.security_disable_totp() == false %}
+  <fieldset>
+    <legend>{{_('Two factor authentication')}}</legend>
+    {% link_for _('Manage two factor authentication'), controller='mfa_user', action='configure_mfa', id=data.id, class_='btn btn-default pull-left', icon='cog' %}
+  </fieldset>
+{% endif %}
+
 {% endblock %}

--- a/ckanext/security/templates/user/edit_user_form.html
+++ b/ckanext/security/templates/user/edit_user_form.html
@@ -8,7 +8,7 @@
   {% endcall %}
 {% endif %}
 
-{% if h.security_disable_totp() == false %}
+{% if not h.security_disable_totp() %}
   <fieldset>
     <legend>{{_('Two factor authentication')}}</legend>
     {% link_for _('Manage two factor authentication'), controller='mfa_user', action='configure_mfa', id=data.id, class_='btn btn-default pull-left', icon='cog' %}

--- a/ckanext/security/templates/user/snippets/login_form.html
+++ b/ckanext/security/templates/user/snippets/login_form.html
@@ -8,8 +8,9 @@ overrides rendering of the login form
 {% set username_error = true if error_summary %}
 {% set password_error = true if error_summary %}
 
-{% asset 'security/mfa_login' %}
-
+{% if h.security_enable_totp() %}
+  {% asset 'security/mfa_login' %}
+{% endif %}
 
 <form id="mfa-login-form" action="{{ action }}" method="post" class="form-horizontal">
   <div class="error-explanation alert alert-error" style="display: none;">
@@ -38,27 +39,29 @@ overrides rendering of the login form
     </div>
   </div>
 
-  <div id="mfa-form" style="display: none;">
-    <fieldset id="mfa-setup" style="display: none;">
-      <legend>{{_('Scan this QR code with your two factor authentication app')}}</legend>
-      <p>{% trans %}If you don't already have an authenticator app, you could try Google Authenticator.{% endtrans %}</p>
+  {% if h.security_enable_totp() %}
+    <div id="mfa-form" style="display: none;">
+      <fieldset id="mfa-setup" style="display: none;">
+        <legend>{{_('Scan this QR code with your two factor authentication app')}}</legend>
+        <p>{% trans %}If you don't already have an authenticator app, you could try Google Authenticator.{% endtrans %}</p>
 
-      <div>
-        <canvas class="radius-lg padding-sm margin-b-sm border-solid" id="qr-code-container"></canvas>
+        <div>
+          <canvas class="radius-lg padding-sm margin-b-sm border-solid" id="qr-code-container"></canvas>
+        </div>
+        <p>
+          {% trans %}If you are not able to scan the QR code, you can manually enter this secret into your authenticator app: {% endtrans %}<code id="totp-secret"></code>
+        </p>
+      </fieldset>
+
+      <p>{{_('Please enter your authenticator app generated 6-digit verification code.')}}</p>
+      {{ form.input('mfa', label=_("Verification code"), id='field-mfa', type="text", value="", error=mfa_error, classes=["control-medium"], attrs={"autocomplete": "off"}) }}
+
+      <input id="mfa-form-active" name="mfa-form-active" type="hidden" value="" />
+      <div class="form-actions">
+        <a id="mfa-help-link" href="/" style="display: none; margin-right: 20px;">{{_('Need help?')}}</a>
+        <button class="btn btn-primary" type="submit">{{ _('Submit') }}</button>
       </div>
-      <p>
-        {% trans %}If you are not able to scan the QR code, you can manually enter this secret into your authenticator app: {% endtrans %}<code id="totp-secret"></code>
-      </p>
-    </fieldset>
-
-    <p>{{_('Please enter your authenticator app generated 6-digit verification code.')}}</p>
-    {{ form.input('mfa', label=_("Verification code"), id='field-mfa', type="text", value="", error=mfa_error, classes=["control-medium"], attrs={"autocomplete": "off"}) }}
-
-    <input id="mfa-form-active" name="mfa-form-active" type="hidden" value="" />
-    <div class="form-actions">
-      <a id="mfa-help-link" href="/" style="display: none; margin-right: 20px;">{{_('Need help?')}}</a>
-      <button class="btn btn-primary" type="submit">{{ _('Submit') }}</button>
     </div>
-  </div>
+  {% endif %}
 
 </form>


### PR DESCRIPTION
In response to https://github.com/data-govt-nz/ckanext-security/issues/40. 

Add option to disable totp using `ckanext.security.enable_totp = false` in configurations. The default value for the flag is `True` if the option is not set in configurations. 