### PR TITLE
Added "if is_flask_request" inside _build_footer_content() to fix notify_lockout() functionality in CKAN 2.9.5

### DIFF
--- a/ckanext/security/mailer.py
+++ b/ckanext/security/mailer.py
@@ -58,8 +58,12 @@ def _build_footer_content(extra_vars):
         template = env.from_string(footer_content)
         return '\n\n' + template.render(**extra_vars)
     else:
-        footer_path = 'security/emails/lockout_footer.txt'
-        return '\n\n' + render_jinja2(footer_path, extra_vars)
+        if is_flask_request():
+            footer_path = 'security/emails/lockout_footer.txt'
+            return '\n\n' + render(footer_path, extra_vars)
+        else:
+            footer_path = 'security/emails/lockout_footer.txt'
+            return '\n\n' + render_jinja2(footer_path, extra_vars)
 
 
 def notify_lockout(user, lockout_timeout):

--- a/ckanext/security/mailer.py
+++ b/ckanext/security/mailer.py
@@ -58,11 +58,10 @@ def _build_footer_content(extra_vars):
         template = env.from_string(footer_content)
         return '\n\n' + template.render(**extra_vars)
     else:
+        footer_path = 'security/emails/lockout_footer.txt'
         if is_flask_request():
-            footer_path = 'security/emails/lockout_footer.txt'
             return '\n\n' + render(footer_path, extra_vars)
         else:
-            footer_path = 'security/emails/lockout_footer.txt'
             return '\n\n' + render_jinja2(footer_path, extra_vars)
 
 


### PR DESCRIPTION
The render_jinja2() call in _build_footer_content() was failing on CKAN 2.9.5, which causes the notify_lockout functionality to fail.

An is_flask_request() conditional was added to fix the problem.