### PR TITLE
Fix auth implementation to return super result

### DIFF
--- a/ckanext/security/authenticator.py
+++ b/ckanext/security/authenticator.py
@@ -87,7 +87,7 @@ class CKANLoginThrottle(UsernamePasswordAuthenticator):
 
         # Run through the CKAN auth sequence first, so we can hit the DB
         # in every case and make timing attacks a little more difficult.
-        auth_user_name = super(CKANLoginThrottle, self).authenticate(
+        ckan_auth_result = super(CKANLoginThrottle, self).authenticate(
             environ, identity)
 
         login_throttle_key = get_login_throttle_key(
@@ -101,19 +101,19 @@ class CKANLoginThrottle(UsernamePasswordAuthenticator):
         if throttle.is_locked():
             return None
 
-        if auth_user_name is None:
+        if ckan_auth_result is None:
             # Increment the throttle counter if the login failed.
             throttle.increment()
 
         # if the CKAN authenticator has successfully authenticated
         # the request and the user wasn't locked out above,
         # then check the TOTP parameter to see if it is valid
-        if auth_user_name is not None:
-            totp_success = self.authenticate_totp(environ, auth_user_name)
+        if ckan_auth_result is not None:
+            totp_success = self.authenticate_totp(environ, user_name)
             # if TOTP was successful -- reset the log in throttle
             if totp_success:
                 throttle.reset()
-                return totp_success
+                return ckan_auth_result
 
     def authenticate_totp(self, environ, auth_user):
         totp_challenger = SecurityTOTP.get_for_user(auth_user)


### PR DESCRIPTION
Base CKAN authenticate function used to return a
username, but was changed in 2.9.6 to return a
comma separated "user_id,1"

We should not have been assuming the return value
of the super.authenticate, we now return the super value after doing our throttle and totp checks.