### PR TITLE
Remove zope.interface requirement as it doesn't appear to be used.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ repoze.who~=2.4
 git+https://github.com/akissa/repoze.who-use_beaker@780379fd58b10264c0756feb6d3f232f797ba0cb#egg=repoze.who-use_beaker
 six~=1.16.0
 WebOb~=1.8.7
-zope.interface~=5.4.0


### PR DESCRIPTION
I can't see anywhere in the code that the `zope.interface` library is used and due to the version being inconsistent to what's used by CKAN I have removed it.