### PR TITLE
Don't get extensions for plaintext files

### DIFF
--- a/ckanext/security/resource_upload_validator.py
+++ b/ckanext/security/resource_upload_validator.py
@@ -57,13 +57,16 @@ def _build_mimetypes_and_extensions(filename, file_content):
         if mimetype:
             extensions_and_mimetypes.append(mimetype)
 
-            # build set of possible extensions for the mimetype
-            nonstandard_extensions = mimes_instance.types_map_inv[0].get(
-                mimetype, [])
-            standard_extensions = mimes_instance.types_map_inv[1].get(
-                mimetype, [])
-            extensions_and_mimetypes.extend(nonstandard_extensions)
-            extensions_and_mimetypes.extend(standard_extensions)
+            # 'text/plain' returns '.bat' extension, if this is blacklisted then
+            # any text files are blocked. Assume text files are ok.
+            if mimetype != 'text/plain':
+                # build set of possible extensions for the mimetype
+                nonstandard_extensions = mimes_instance.types_map_inv[0].get(
+                    mimetype, [])
+                standard_extensions = mimes_instance.types_map_inv[1].get(
+                    mimetype, [])
+                extensions_and_mimetypes.extend(nonstandard_extensions)
+                extensions_and_mimetypes.extend(standard_extensions)
 
     unique_set = set(extensions_and_mimetypes)
     unique_list = list(unique_set)


### PR DESCRIPTION
This issue was originally reported in https://github.com/data-govt-nz/ckanext-security/issues/42

We ran into this after altering the base docker image that our CKAN installation was hosted in. It appears that some versions of debian set the mime.config files in such a way that text/plain does not resolve to a .bat extension, and others do.

This change means that plain text files will no longer be blocked based on guessing the possible extension and matching against the blacklist.

If you want to explicitly block plaintext files, you can add 'text/plain' to the block list.