### PR TITLE
resources with no url/file are safe

### DIFF
--- a/ckanext/security/plugin/__init__.py
+++ b/ckanext/security/plugin/__init__.py
@@ -53,14 +53,18 @@ class CkanSecurityPlugin(MixinPlugin, p.SingletonPlugin):
     # BEGIN Hooks for IResourceController
 
     def before_create(self, context, resource):
-        validate_upload_presence(resource)
+        try:
+            validate_upload_presence(resource)
+        except tk.ValidationError:
+            return
         validate_upload_type(resource)
-        pass
 
     def before_update(self, context, current, resource):
-        validate_upload_presence(resource)
+        try:
+            validate_upload_presence(resource)
+        except tk.ValidationError:
+            return
         validate_upload_type(resource)
-        pass
 
     # END Hooks for IResourceController
 


### PR DESCRIPTION
These validation rules prevent creation of datastore-only resources or resources that don't (yet) have a link to a file. I can't think of a reason that creating resources with no url or file should be prevented by ckanext-security.