### PR TITLE
Abort if user/pass auth success but no MFA

### DIFF
--- a/ckanext/security/authenticator.py
+++ b/ckanext/security/authenticator.py
@@ -67,6 +67,12 @@ def authenticate(identity):
     # Run through the CKAN auth sequence first, so we can hit the DB
     # in every case and make timing attacks a little more difficult.
     ckan_auth_result = default_authenticate(identity)
+
+    # Don't throttle or check MFA in other parts of the application
+    # like user/edit/<username> when changing password
+    if 'user/login' not in request.path:
+        return ckan_auth_result
+
     try:
         user_name = identity['login']
     except KeyError:

--- a/ckanext/security/authenticator.py
+++ b/ckanext/security/authenticator.py
@@ -78,10 +78,10 @@ def authenticate(identity):
         return None
 
     throttle = LoginThrottle(User.by_name(user_name), login_throttle_key)
-    # Check if there is a lock on the requested user, and return None if
+    # Check if there is a lock on the requested user, and abort if
     # we have a lock.
     if throttle.is_locked():
-        return None
+        return abort(403, 'Too many login attempts, please try again later')
 
     if ckan_auth_result is None:
         # Increment the throttle counter if the login failed.

--- a/ckanext/security/plugin/flask_plugin.py
+++ b/ckanext/security/plugin/flask_plugin.py
@@ -22,8 +22,8 @@ class MixinPlugin(p.SingletonPlugin):
 
     # IAuthenticator
 
-    def authenticate(self, identity):
-        return authenticator.authenticate(identity)
+    def login(self):
+        return authenticator.login()
 
     # Delete session cookie information
     def logout(self):


### PR DESCRIPTION
The MFA implementation leverages an ajax form submit to add the two step user/pass then MFA code form structure into CKAN.

Once that ajax response from the /api/login succeeds the login form does a normal form POST submit to the overridden IAuthenticator implementation, which rechecks the user/pass and MFA, and returns the result of the default CKAN authenticator if everything succeeds.

We were returning "None" in the case that MFA fails, however the IAuthenticator implementation in CKAN core falls back to user/pass auth if the plugin returns None, so this meant that the form was able to be submitted with no MFA and as long as the user/pass was correct the user could still log in.

This required malicious intent, either through man-in-the-middle to alter the response of the /api/login call, or crafting a form submit request with valid user/pass and no MFA to /user/login.