### PR TITLE
Replace Monkey Patching with `IValidators` Implementation

### DIFF
--- a/ckanext/security/logic/action.py
+++ b/ckanext/security/logic/action.py
@@ -1,7 +1,8 @@
 from ckan.plugins.toolkit import (
     get_action,
     chained_action,
-    check_access, get_or_bust)
+    check_access, get_or_bust,
+    get_validator)
 from ckanext.security.authenticator import (
     get_user_throttle,
     get_address_throttle,
@@ -9,6 +10,7 @@ from ckanext.security.authenticator import (
     reset_address_throttle,
     reset_totp
 )
+from ckan.logic.schema import default_update_user_schema
 
 
 def security_throttle_user_reset(context, data_dict):
@@ -67,6 +69,10 @@ def user_update(up_func, context, data_dict):
     ckanext-security: reset throttling information for updated users
     to allow new login attempts after password reset
     """
+    old_username_validator = get_validator('old_username_validator')
+    if 'schema' not in context:
+        context['schema'] = default_update_user_schema()
+    context['schema']['name'].append(old_username_validator)
     rval = up_func(context, data_dict)
     get_action('security_throttle_user_reset')(
         dict(context, ignore_auth=True), {'user': rval['name']})

--- a/ckanext/security/plugin/__init__.py
+++ b/ckanext/security/plugin/__init__.py
@@ -10,6 +10,7 @@ from ckanext.security.resource_upload_validator import (
 )
 from ckanext.security.logic import auth, action
 from ckanext.security.helpers import security_enable_totp
+from ckanext.security import validators
 
 from ckanext.security.plugin.flask_plugin import MixinPlugin
 
@@ -22,29 +23,27 @@ class CkanSecurityPlugin(MixinPlugin, p.SingletonPlugin):
     p.implements(p.IActions)
     p.implements(p.IAuthFunctions)
     p.implements(p.ITemplateHelpers)
+    p.implements(p.IValidators, inherit=True)
 
     # BEGIN Hooks for IConfigurer
 
     def update_config(self, config):
         define_security_tables()  # map security models to db schema
 
-        # Monkeypatching all user schemas in order to enforce a stronger
-        # password policy. I tried monkeypatching
-        # `ckan.logic.validators.user_password_validator` instead
-        # without success.
-        core_schema.default_user_schema = \
-            ext_schema.default_user_schema
-        core_schema.user_new_form_schema = \
-            ext_schema.user_new_form_schema
-        core_schema.user_edit_form_schema = \
-            ext_schema.user_edit_form_schema
-        core_schema.default_update_user_schema = \
-            ext_schema.default_update_user_schema
-
         tk.add_template_directory(config, '../templates')
         tk.add_resource('../fanstatic', 'security')
 
     # END Hooks for IConfigurer
+
+    # BEGIN Hooks for IValidators
+
+    def get_validators(self):
+        return {
+            'user_password_validator': validators.user_password_validator,
+            'old_username_validator': validators.old_username_validator,
+        }
+
+    # END Hooks for IValidators
 
     # BEGIN Hooks for IResourceController
 


### PR DESCRIPTION
fix(logic): replace monkey patching;

- Remove monkey patches.
- Added `IValidators` implementation.

Because CKAN Core does not really have schema/pluggables for the User stuff as of yet, we just have to append any validators to the contextual schemas in chained user action methods.