### PR TITLE
Account Lockout Fixes

### DIFF
--- a/ckanext/security/plugin/flask_plugin.py
+++ b/ckanext/security/plugin/flask_plugin.py
@@ -25,6 +25,9 @@ class MixinPlugin(p.SingletonPlugin):
     def login(self):
         return authenticator.login()
 
+    def authenticate(self, identity):
+        return authenticator.authenticate(identity)
+
     # Delete session cookie information
     def logout(self):
         session.invalidate()


### PR DESCRIPTION
fix(logic): 2.9 mail context;

- Fixed the no app and request context in CKAN <= 2.9 when the account lockout email is sent.
- Added the `authenticate` implementation method to the security plugin.