### PR TITLE
Add ability to login with email address

### DIFF
--- a/ckanext/security/utils.py
+++ b/ckanext/security/utils.py
@@ -125,6 +125,8 @@ def login():
 
         user_name = identity['login']
         user = model.User.by_name(user_name)
+        if not user:
+            user = model.User.by_email(user_name)
 
         login_throttle_key = get_login_throttle_key(request, user_name)
         if login_throttle_key is None:


### PR DESCRIPTION
CKAN 2.10 added the ability to login with email address in addition to username.

In this PR I have added this capability to ckanext-security.

I may need to do something about the way this interacts with throttling. As it is currently implemented, a separate security_throttle_key is tracked for a user's email and user_name. So, for instance, an attacker could theoretically attempt `ckanext.security.login_max_count` logins every `ckanext.security.lock_timeout` seconds on an email address and a user_name separately, _technically_ doubling the threat exposure. 

I know this isn't optimal, but I also don't know how big of an issue I consider it. It would be better if only one security_throttle_key was tracked but that is beyond the scope of what I have time to implement here and now. 

Interested to hear if you think this fix is worth merging as it is or if (a) I have introduced non-throttling related security problems with what I have proposed so far or (b) I should first work to also consolidate the security_throttle_keys into one per user as part of this PR.

Thanks, hope this is useful.