### PR TITLE
Fix CKAN 2.11 compatibility: use session.clear() for Flask-Session

### DIFF
--- a/ckanext/security/plugin/flask_plugin.py
+++ b/ckanext/security/plugin/flask_plugin.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import ckan.plugins as p
+from ckan.plugins import toolkit as tk
 from ckanext.security import views, cli, authenticator
 from ckan.common import session
 
@@ -27,4 +28,8 @@ class MixinPlugin(p.SingletonPlugin):
 
     # Delete session cookie information
     def logout(self):
-        session.invalidate()
+        # CKAN 2.11+ uses Flask-Session which has clear() instead of invalidate()
+        if tk.check_ckan_version(min_version='2.11'):
+            session.clear()
+        else:
+            session.invalidate()


### PR DESCRIPTION
## Summary

Fixes #90 - CKAN 2.11 replaced Beaker with Flask-Session for session management. The `logout()` method was calling `session.invalidate()` which doesn't exist in Flask-Session, causing an `AttributeError: 'RedisSession' object has no attribute 'invalidate'` error.

## Solution

Added a CKAN version check to use the appropriate session termination method:
- **CKAN 2.11+**: `session.clear()` (Flask-Session API)
- **CKAN <2.11**: `session.invalidate()` (Beaker API)

This maintains backward compatibility with older CKAN versions while fixing the logout error in 2.11+.

## Changes

- `ckanext/security/plugin/flask_plugin.py`: Import toolkit, add version-conditional logout logic

## References

- CKAN 2.11 migration notes: https://docs.ckan.org/en/2.11/changelog.html#migration-notes-2-11
- Related work by @twdbben: https://github.com/TNRIS/ckanext-security/commit/e449fd48254a69f6c282d53bc784563dc9c3a60a