### PR TITLE
Remove six library dependency

### DIFF
--- a/ckanext/security/mailer.py
+++ b/ckanext/security/mailer.py
@@ -2,7 +2,6 @@
 import os
 import codecs
 import logging
-import six
 import flask
 
 from ckan.common import config
@@ -19,7 +18,7 @@ def make_key():
 
 
 def create_reset_key(user):
-    user.reset_key = six.ensure_text(make_key())
+    user.reset_key = make_key().decode('ascii')
     model.repo.commit_and_remove()
 
 

--- a/ckanext/security/schema.py
+++ b/ckanext/security/schema.py
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-import six
-
 from ckan.lib.navl.validators import ignore_missing, not_empty, ignore
 from ckan.logic.validators import (
     name_validator, user_name_validator, user_password_not_empty,

--- a/ckanext/security/validators.py
+++ b/ckanext/security/validators.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-import six
 import string
 
 from ckan import authz
@@ -19,7 +18,7 @@ def user_password_validator(key, data, errors, context):
 
     if isinstance(value, Missing):
         pass  # Already handled in core
-    elif not isinstance(value, six.string_types):
+    elif not isinstance(value, str):
         raise Invalid(_('Passwords must be strings.'))
     elif value == '':
         pass  # Already handled in core
@@ -42,4 +41,4 @@ def old_username_validator(key, data, errors, context):
 
 
 def ensure_str(value):
-    return six.text_type(value)
+    return str(value)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,4 @@ python-magic~=0.4.24
 redis~=4.1
 repoze.who~=2.4
 git+https://github.com/akissa/repoze.who-use_beaker@780379fd58b10264c0756feb6d3f232f797ba0cb#egg=repoze.who-use_beaker
-six~=1.16.0
 WebOb~=1.8.7


### PR DESCRIPTION
## Summary

Removes the `six` library (Python 2/3 compatibility shim) as it is no longer needed. Python 2 reached end-of-life in January 2020, and CKAN has dropped Python 2 support.

Closes #88

## Changes

- **`validators.py`**: Replace `six.string_types` with `str`, `six.text_type()` with `str()`
- **`mailer.py`**: Replace `six.ensure_text()` with `bytes.decode('ascii')`
- **`schema.py`**: Remove unused `import six`
- **`requirements.txt`**: Remove `six~=1.16.0`

## Testing

All replacements are direct equivalents in Python 3:
- `six.string_types` → `str` (in Python 3, `six.string_types` is just `(str,)`)
- `six.text_type` → `str` (in Python 3, `six.text_type` is `str`)
- `six.ensure_text(bytes_val)` → `bytes_val.decode('ascii')` (`make_key()` returns hex-encoded bytes, always ASCII-safe)